### PR TITLE
fix(BezelNotification): handle non-RGB colorspace for background tint alpha

### DIFF
--- a/Sources/Howl/Configuration/BezelNotificationParameters.swift
+++ b/Sources/Howl/Configuration/BezelNotificationParameters.swift
@@ -240,7 +240,11 @@ public extension BezelNotificationParameters {
             #if canImport(AppKit)
                 rawBackgroundTintAlpha = rawBackgroundTint.alphaComponent
             #else
-                rawBackgroundTint.getRed(nil, green: nil, blue: nil, alpha: &rawBackgroundTintAlpha)
+                var alpha: CGFloat = 0
+                if !rawBackgroundTint.getRed(nil, green: nil, blue: nil, alpha: &alpha) {
+                    alpha = rawBackgroundTint.alphaComponent
+                }
+                rawBackgroundTintAlpha = alpha
             #endif
             
             return rawBackgroundTint.withAlphaComponent(rawBackgroundTintAlpha * 0.15)


### PR DESCRIPTION
When rawBackgroundTint is not in an RGB colorspace, getRed() returns false and the alpha parameter is left unmodified (zero), making the tint fully-transparent. Use alphaComponent as a fallback for non-RGB colorspaces so that tint works correctly regardless of the source color's colorspace.

Fixes #28